### PR TITLE
Fix restraint handling in dynamics app

### DIFF
--- a/apps/Dyna/src/simulator.cpp
+++ b/apps/Dyna/src/simulator.cpp
@@ -105,7 +105,8 @@ int main(int argc, const char* argv[]) {
   UserSettings ui(clip, { "-pe", "-ce" });
   
   // Read topologies and coordinate files.  Assemble critical deatils about each system.
-  SystemCache sc(ui.getFilesNamelistInfo(), ui.getExceptionBehavior(), MapRotatableGroups::NO,
+  SystemCache sc(ui.getFilesNamelistInfo(), ui.getRestraintNamelistInfo(),
+                 ui.getDynamicsNamelistInfo(), ui.getExceptionBehavior(), MapRotatableGroups::NO,
                  ui.getPrintingPolicy());
   timer.assignTime(file_parse_tm);
 

--- a/src/Namelists/input.cpp
+++ b/src/Namelists/input.cpp
@@ -240,7 +240,10 @@ std::vector<std::string> pullNamelist(const TextFile &tf, const NamelistEmulator
           }
 
           // Return this result: it was the first instance of the namelist
-          *end_line = next_line;
+          // next_line has already been advanced once after processing the terminating line.
+          // Return the first line after the namelist so that an immediately adjacent namelist
+          // is not skipped by a subsequent non-wrapping search.
+          *end_line = next_line - 1;
           return result;
         }
       }

--- a/test/Parsing/test_input.cpp
+++ b/test/Parsing/test_input.cpp
@@ -337,6 +337,26 @@ int main(const int argc, const char* argv[]) {
   check(my_int, RelationalOperator::EQUAL, 8, "An integer variable was not assigned correctly.");
   check(trip_int, RelationalOperator::EQUAL, std::vector<int>(3, 8), "Integers were not assigned "
         "as expected in triplicate by a generic &namelist object.");
+
+  // Consecutive namelists can appear without a blank line between the first terminator and the
+  // next title.  The returned line cursor must point at that next title, not one line beyond it.
+  const std::string adjacent_input("&dtopic\n  kw_integer 17,\n&end\n"
+                                   "&dtopic\n  kw_integer 29,\n&end\n");
+  const TextFile adjacent_tf(adjacent_input, TextOrigin::RAM);
+  NamelistEmulator adjacent_a = genericNamelist();
+  NamelistEmulator adjacent_b = genericNamelist();
+  bool adjacent_a_found = false;
+  bool adjacent_b_found = false;
+  start_line = readNamelist(adjacent_tf, &adjacent_a, 0, WrapTextSearch::NO,
+                            adjacent_tf.getLineCount(), &adjacent_a_found);
+  start_line = readNamelist(adjacent_tf, &adjacent_b, start_line, WrapTextSearch::NO,
+                            adjacent_tf.getLineCount(), &adjacent_b_found);
+  check(adjacent_a_found && adjacent_b_found, "An immediately adjacent second namelist was not "
+        "found when continuing from the line cursor returned by readNamelist().");
+  check(adjacent_a.getIntValue("kw_integer"), RelationalOperator::EQUAL, 17,
+        "The first of two immediately adjacent namelists was not read correctly.");
+  check(adjacent_b.getIntValue("kw_integer"), RelationalOperator::EQUAL, 29,
+        "The second of two immediately adjacent namelists was not read correctly.");
   
   // Testing the UserSettings Class
   section(4);


### PR DESCRIPTION
## Summary

This PR fixes two independent issues that compounded to make positional restraints in
`dynamics.stormm` silently ineffective:

1. `dynamics.stormm` parsed `&restraint` and `&dynamics` controls, but constructed
   `SystemCache` through an overload that received neither. All restraint controls were therefore
   dropped before minimization or dynamics.
2. Once that plumbing was fixed, immediately adjacent repeated namelists exposed an off-by-one
   cursor in `pullNamelist()`. The cursor skipped the title of the following namelist, so the
   second, fourth, sixth, ... adjacent `&restraint` blocks were not parsed.

The first commit passes both parsed control objects into `SystemCache`. The second returns the
correct continuation line from `pullNamelist()` and adds a generic regression test for adjacent
repeated namelists.

## User-visible failure

- On `main`, changing a restraint penalty from 100 to 10,000 kcal/mol/A^2 produced bit-identical
  restart files in `dynamics.stormm`: no parsed restraint reached the `RestraintApparatus`.
- With only commit `7ed65a3`, a deck containing ten adjacent `&restraint` blocks applied only
  blocks 1, 3, 5, 7, and 9. In the peptide reproducer this restrained positions 1, 3, 6, 8, and
  10 while positions 2, 5, 7, 9, and 11 moved as if unrestrained.
- A blank line between blocks masked the parser problem because the incorrectly advanced cursor
  skipped the blank line instead of the next namelist title.

## Self-contained application reproducer

The following uses `gly_arg.top` and `gly_arg.inpcrd`, which are already in this repository.
Run it from the repository root after building `dynamics.stormm` (replace `$BUILD` with the build
directory):

```bash
cat > /tmp/stormm-restraint-repro.in <<EOF
&files
  -sys { -p $PWD/test/Namelists/topol/gly_arg.top
         -c $PWD/test/Namelists/coord/gly_arg.inpcrd
         -r /tmp/restrained_a.rst7 -label A }
  -sys { -p $PWD/test/Namelists/topol/gly_arg.top
         -c $PWD/test/Namelists/coord/gly_arg.inpcrd
         -r /tmp/restrained_b.rst7 -label B }
  -sys { -p $PWD/test/Namelists/topol/gly_arg.top
         -c $PWD/test/Namelists/coord/gly_arg.inpcrd
         -r /tmp/unrestrained.rst7 -label C }
&end
&solvent
  igb = 8,
&end
&restraint
  ensemble = positions, mask = '@N,CA,C,O', penalty = 10000.0, system = A,
&end
&restraint
  ensemble = positions, mask = '@N,CA,C,O', penalty = 10000.0, system = B,
&end
&minimize
  maxcyc = 300, ncyc = 100, cdcyc = 50, drms = 0.0001,
&end
EOF

$BUILD/apps/Dyna/dynamics.stormm -O -i /tmp/stormm-restraint-repro.in -except warn
sha256sum /tmp/restrained_a.rst7 /tmp/restrained_b.rst7 /tmp/unrestrained.rst7
```

Expected relationships:

| revision | A vs B | B vs C | interpretation |
|---|---|---|---|
| `main` before this PR | identical | identical | all parsed restraints are dropped |
| `7ed65a3` only | different | identical | first adjacent block is applied; second is skipped |
| PR head (`21bd22d`) | identical | different | both adjacent blocks are applied |

## Minimal parser reproducer and regression test

The parser failure needs no topology or GPU. The new test makes two namelists directly adjacent:

```text
&dtopic
  kw_integer 17,
&end
&dtopic
  kw_integer 29,
&end
```

It calls `readNamelist()` twice with `WrapTextSearch::NO`, continuing from the cursor returned by
the first call. Before `21bd22d`, the first object was found with value 17 but the second title was
skipped. At PR head, both are found and retain values 17 and 29.

Build and run just this regression test:

```bash
cmake -S . -B build \
  -DCMAKE_BUILD_TYPE=Release \
  -DSTORMM_ENABLE_CUDA=ON \
  -DSTORMM_ENABLE_RDKIT=OFF \
  -DSTORMM_INCLUDE_POCKETFFT=OFF \
  -DSTORMM_INCLUDE_NETCDF=OFF \
  -DSTORMM_BUILD_TESTS=ON \
  -DSTORMM_BUILD_BENCHMARKS=OFF \
  -DSTORMM_BUILD_APPS=ON
cmake --build build --target test_input dynamics.stormm.cuda -j 4
ctest --test-dir build -R '^test_input$' --output-on-failure
```

## Root causes and fixes

### 1. Dyna did not pass parsed controls into `SystemCache`

`UserSettings` already advertised and parsed `&restraint`, but `apps/Dyna/src/simulator.cpp`
selected the `SystemCache` overload without restraint controls. That overload delegates with an
empty restraint list. The fix passes `ui.getRestraintNamelistInfo()` and
`ui.getDynamicsNamelistInfo()` to the constructor.

### 2. `pullNamelist()` returned a cursor one line too far

When `pullNamelist()` processes `&end`, `next_line` has already advanced past the terminating
line. Returning `next_line` as the next search position advances it once more, past the title of
an immediately adjacent namelist. Returning `next_line - 1` makes the next non-wrapping search
begin at that title.

## Validation performed

- PR head: `21bd22db804e12353a758edabb7a476588f22c81`.
- Linux / CUDA 12.6 release build completed for `test_input` and
  `dynamics.stormm.cuda`.
- `ctest -R '^test_input$' --output-on-failure`: passed in 0.97 s (100% tests passed).
- Application-level validation: 75 ff14SB / GBn2 receptor-bound peptide rotamers in one
  synthesis, with ten immediately adjacent position-restraint blocks, 300 minimization cycles,
  three independent process repeats on an NVIDIA L4.
- Restraint audit passed for every system: worst fixed-heavy-atom RMS displacement was
  0.00691 A and worst fixed-atom displacement was 0.0944 A (predeclared gates: 0.02 A and
  0.2 A).
- Median process time was 8.316 s; median minimization-kernel time was 4.903 s.

The parser regression is generic (`&dtopic`) because the cursor bug affects any adjacent repeated
namelist, not only `&restraint`.
